### PR TITLE
Add host-side tests for measurement conversions and alarms

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,3 +20,8 @@ extra_scripts = scripts/patch_sslclient.py
 board_build.partitions = default.csv
 monitor_speed = 115200
 upload_speed = 921600
+
+[env:native]
+platform = native
+build_flags = -std=gnu++17
+test_build_src = false

--- a/src/logic_utils.h
+++ b/src/logic_utils.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "alarm_types.h"
+
+// Some build environments (e.g. native PlatformIO tests) will not provide the
+// Adafruit ADS library.  We only need the gain enumeration for the helper
+// logic, so provide a lightweight stand-in when the library is unavailable.
+#ifndef GAIN_TWOTHIRDS
+typedef enum {
+  GAIN_TWOTHIRDS = 0,
+  GAIN_ONE,
+  GAIN_TWO,
+  GAIN_FOUR,
+  GAIN_EIGHT,
+  GAIN_SIXTEEN
+} adsGain_t;
+#endif
+
+namespace logic {
+
+struct AlarmThresholds {
+  float underSet;
+  float underClear;
+  float overSet;
+  float overClear;
+};
+
+inline float adsLSB_mV(adsGain_t g) {
+  switch (g) {
+    case GAIN_TWOTHIRDS: return 0.1875f;
+    case GAIN_ONE:       return 0.1250f;
+    case GAIN_TWO:       return 0.0625f;
+    case GAIN_FOUR:      return 0.03125f;
+    case GAIN_EIGHT:     return 0.015625f;
+    case GAIN_SIXTEEN:   return 0.0078125f;
+  }
+  return 0.1250f;
+}
+
+inline float mapCurrentPctToMm(float pct, float fullScaleMm, float offsetMm) {
+  float clamped = pct;
+  if (clamped < 0.0f) clamped = 0.0f;
+  if (clamped > 100.0f) clamped = 100.0f;
+  return (clamped / 100.0f) * fullScaleMm + offsetMm;
+}
+
+inline AlarmState evalWithHyst(AlarmState cur, float mA,
+                               const AlarmThresholds& th) {
+  if (cur == ALARM_NORMAL) {
+    if (mA < th.underSet) return ALARM_UNDER;
+    if (mA > th.overSet)  return ALARM_OVER;
+    return ALARM_NORMAL;
+  }
+
+  if (cur == ALARM_UNDER) {
+    if (mA > th.underClear) return ALARM_NORMAL;
+    if (mA > th.overSet)    return ALARM_OVER;  // direct jump allowed
+    return ALARM_UNDER;
+  }
+
+  // cur == ALARM_OVER
+  if (mA < th.overClear) return ALARM_NORMAL;
+  if (mA < th.underSet)  return ALARM_UNDER;    // direct jump allowed
+  return ALARM_OVER;
+}
+
+inline uint8_t gainToCode(adsGain_t g) {
+  switch (g) {
+    case GAIN_TWOTHIRDS: return 0;
+    case GAIN_ONE:       return 1;
+    case GAIN_TWO:       return 2;
+    case GAIN_FOUR:      return 3;
+    case GAIN_EIGHT:     return 4;
+    case GAIN_SIXTEEN:   return 5;
+  }
+  return 1;
+}
+
+inline adsGain_t codeToGain(uint8_t code) {
+  switch (code) {
+    case 0: return GAIN_TWOTHIRDS;
+    case 1: return GAIN_ONE;
+    case 2: return GAIN_TWO;
+    case 3: return GAIN_FOUR;
+    case 4: return GAIN_EIGHT;
+    case 5: return GAIN_SIXTEEN;
+    default: return GAIN_ONE;
+  }
+}
+
+}  // namespace logic
+

--- a/test/logic/test_main.cpp
+++ b/test/logic/test_main.cpp
@@ -1,0 +1,60 @@
+#include <unity.h>
+
+#include "logic_utils.h"
+
+using logic::AlarmThresholds;
+
+namespace {
+constexpr AlarmThresholds kThresholds{3.0f, 3.5f, 22.0f, 21.5f};
+}
+
+void test_ads_lsb_mv_lookup() {
+  TEST_ASSERT_FLOAT_WITHIN(1e-6, 0.1875f, logic::adsLSB_mV(GAIN_TWOTHIRDS));
+  TEST_ASSERT_FLOAT_WITHIN(1e-6, 0.1250f, logic::adsLSB_mV(GAIN_ONE));
+  TEST_ASSERT_FLOAT_WITHIN(1e-6, 0.0625f, logic::adsLSB_mV(GAIN_TWO));
+  TEST_ASSERT_FLOAT_WITHIN(1e-6, 0.03125f, logic::adsLSB_mV(GAIN_FOUR));
+  TEST_ASSERT_FLOAT_WITHIN(1e-6, 0.015625f, logic::adsLSB_mV(GAIN_EIGHT));
+  TEST_ASSERT_FLOAT_WITHIN(1e-6, 0.0078125f, logic::adsLSB_mV(GAIN_SIXTEEN));
+}
+
+void test_map_current_pct_to_mm_clamps_and_scales() {
+  TEST_ASSERT_FLOAT_WITHIN(1e-6, 0.0f, logic::mapCurrentPctToMm(-10.0f, 40.0f, 0.0f));
+  TEST_ASSERT_FLOAT_WITHIN(1e-6, 20.0f, logic::mapCurrentPctToMm(50.0f, 40.0f, 0.0f));
+  TEST_ASSERT_FLOAT_WITHIN(1e-6, 60.0f, logic::mapCurrentPctToMm(150.0f, 40.0f, 20.0f));
+}
+
+void test_alarm_hysteresis_transitions() {
+  // Normal -> under/over
+  TEST_ASSERT_EQUAL_UINT8(ALARM_UNDER, logic::evalWithHyst(ALARM_NORMAL, 2.9f, kThresholds));
+  TEST_ASSERT_EQUAL_UINT8(ALARM_OVER, logic::evalWithHyst(ALARM_NORMAL, 23.0f, kThresholds));
+  TEST_ASSERT_EQUAL_UINT8(ALARM_NORMAL, logic::evalWithHyst(ALARM_NORMAL, 12.0f, kThresholds));
+
+  // Under -> normal when above clear, or -> over when jumping high
+  TEST_ASSERT_EQUAL_UINT8(ALARM_NORMAL, logic::evalWithHyst(ALARM_UNDER, 3.6f, kThresholds));
+  TEST_ASSERT_EQUAL_UINT8(ALARM_OVER, logic::evalWithHyst(ALARM_UNDER, 23.0f, kThresholds));
+  TEST_ASSERT_EQUAL_UINT8(ALARM_UNDER, logic::evalWithHyst(ALARM_UNDER, 3.2f, kThresholds));
+
+  // Over -> normal or -> under when dropping far
+  TEST_ASSERT_EQUAL_UINT8(ALARM_NORMAL, logic::evalWithHyst(ALARM_OVER, 21.0f, kThresholds));
+  TEST_ASSERT_EQUAL_UINT8(ALARM_UNDER, logic::evalWithHyst(ALARM_OVER, 2.5f, kThresholds));
+  TEST_ASSERT_EQUAL_UINT8(ALARM_OVER, logic::evalWithHyst(ALARM_OVER, 22.5f, kThresholds));
+}
+
+void test_gain_code_round_trip() {
+  for (uint8_t code = 0; code <= 5; ++code) {
+    adsGain_t gain = logic::codeToGain(code);
+    TEST_ASSERT_EQUAL_UINT8(code, logic::gainToCode(gain));
+  }
+}
+
+int main(int argc, char **argv) {
+  (void)argc;
+  (void)argv;
+  UNITY_BEGIN();
+  RUN_TEST(test_ads_lsb_mv_lookup);
+  RUN_TEST(test_map_current_pct_to_mm_clamps_and_scales);
+  RUN_TEST(test_alarm_hysteresis_transitions);
+  RUN_TEST(test_gain_code_round_trip);
+  return UNITY_END();
+}
+


### PR DESCRIPTION
## Summary
- factor shared measurement and alarm helper logic into a reusable header
- configure a native PlatformIO environment for host-based unit testing
- add unit tests that validate ADS gain scaling, mm conversion, alarm hysteresis, and gain-code round trips

## Testing
- ⚠️ `pio test -e native` *(fails: PlatformIO CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7cb4ff9c48330b80efe4f3e4c74fe