### PR TITLE
Fix formatCsvRow placement to use complete Frame8 type

### DIFF
--- a/src/esp32-http-server.ino
+++ b/src/esp32-http-server.ino
@@ -134,70 +134,6 @@ static String csvCompanionPath(const String& binPath) {
   return csv;
 }
 
-static String formatCsvRow(const Frame8& fr, const MeasHeader& h,
-                           bool wantMV, bool wantFULL,
-                           float lsb0, float lsb1) {
-  float t = (fr.t_10us * (h.time_scale_us / 1e6f)); // seconds
-  float mv0 = fr.raw0 * lsb0;
-  float mv1 = fr.raw1 * lsb1;
-
-  String line;
-  line.reserve(96);
-  line += String(t,6) + "," + String(fr.raw0) + "," + String(fr.raw1);
-  if (wantMV) {
-    line += "," + String(mv0,3) + "," + String(mv1,3);
-  }
-  if (wantFULL) {
-    float ma0 = (h.sh0>0.1f)? (mv0/h.sh0) : 0.0f;
-    float ma1 = (h.sh1>0.1f)? (mv1/h.sh1) : 0.0f;
-    float pct0 = ((ma0-4.0f)/16.0f)*100.0f; if (pct0<0) pct0=0; if (pct0>100) pct0=100;
-    float pct1 = ((ma1-4.0f)/16.0f)*100.0f; if (pct1<0) pct1=0; if (pct1>100) pct1=100;
-    float mm0 = (pct0/100.0f)*h.fs0 + h.off0;
-    float mm1 = (pct1/100.0f)*h.fs1 + h.off1;
-    line += "," + String(ma0,3) + "," + String(ma1,3)
-         +  "," + String(mm0,2) + "," + String(mm1,2);
-  }
-  line += "\n";
-  return line;
-}
-
-static String csvCompanionPath(const String& binPath) {
-  String csv = binPath;
-  int dot = csv.lastIndexOf('.');
-  if (dot > 0) {
-    csv = csv.substring(0, dot);
-  }
-  csv += "_full.csv";
-  return csv;
-}
-
-static String formatCsvRow(const Frame8& fr, const MeasHeader& h,
-                           bool wantMV, bool wantFULL,
-                           float lsb0, float lsb1) {
-  float t = (fr.t_10us * (h.time_scale_us / 1e6f)); // seconds
-  float mv0 = fr.raw0 * lsb0;
-  float mv1 = fr.raw1 * lsb1;
-
-  String line;
-  line.reserve(96);
-  line += String(t,6) + "," + String(fr.raw0) + "," + String(fr.raw1);
-  if (wantMV) {
-    line += "," + String(mv0,3) + "," + String(mv1,3);
-  }
-  if (wantFULL) {
-    float ma0 = (h.sh0>0.1f)? (mv0/h.sh0) : 0.0f;
-    float ma1 = (h.sh1>0.1f)? (mv1/h.sh1) : 0.0f;
-    float pct0 = ((ma0-4.0f)/16.0f)*100.0f; if (pct0<0) pct0=0; if (pct0>100) pct0=100;
-    float pct1 = ((ma1-4.0f)/16.0f)*100.0f; if (pct1<0) pct1=0; if (pct1>100) pct1=100;
-    float mm0 = (pct0/100.0f)*h.fs0 + h.off0;
-    float mm1 = (pct1/100.0f)*h.fs1 + h.off1;
-    line += "," + String(ma0,3) + "," + String(ma1,3)
-         +  "," + String(mm0,2) + "," + String(mm1,2);
-  }
-  line += "\n";
-  return line;
-}
-
 // Map 4–20 mA % to mm for channel ch (0=A0, 1=A1)
 static float mapToMM(uint8_t ch, float pct){
   if (ch > 1) ch = 1;
@@ -345,6 +281,33 @@ struct __attribute__((packed)) Frame8 {
   int16_t  raw0;
   int16_t  raw1;
 };
+
+static String formatCsvRow(const Frame8& fr, const MeasHeader& h,
+                           bool wantMV, bool wantFULL,
+                           float lsb0, float lsb1) {
+  float t = (fr.t_10us * (h.time_scale_us / 1e6f)); // seconds
+  float mv0 = fr.raw0 * lsb0;
+  float mv1 = fr.raw1 * lsb1;
+
+  String line;
+  line.reserve(96);
+  line += String(t,6) + "," + String(fr.raw0) + "," + String(fr.raw1);
+  if (wantMV) {
+    line += "," + String(mv0,3) + "," + String(mv1,3);
+  }
+  if (wantFULL) {
+    float ma0 = (h.sh0>0.1f)? (mv0/h.sh0) : 0.0f;
+    float ma1 = (h.sh1>0.1f)? (mv1/h.sh1) : 0.0f;
+    float pct0 = ((ma0-4.0f)/16.0f)*100.0f; if (pct0<0) pct0=0; if (pct0>100) pct0=100;
+    float pct1 = ((ma1-4.0f)/16.0f)*100.0f; if (pct1<0) pct1=0; if (pct1>100) pct1=100;
+    float mm0 = (pct0/100.0f)*h.fs0 + h.off0;
+    float mm1 = (pct1/100.0f)*h.fs1 + h.off1;
+    line += "," + String(ma0,3) + "," + String(ma1,3)
+         +  "," + String(mm0,2) + "," + String(mm1,2);
+  }
+  line += "\n";
+  return line;
+}
 
 // ---------- Logger state (non-live, batched) ----------
 static const size_t BATCH_FRAMES = 1024;         // 512 * 8 = 4096 B per flush


### PR DESCRIPTION
## Summary
- move the formatCsvRow helper implementation to follow the MeasHeader and Frame8 struct definitions
- drop the duplicate csvCompanionPath implementation left near the top of the sketch

## Testing
- platformio run *(fails: command not found: platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68d986bc3b5883309130589aa1faaa15